### PR TITLE
Add nldj to libraries, listify library links

### DIFF
--- a/libraries.html
+++ b/libraries.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" type="text/css" href="stylesheets/pygment_trac.css" media="screen" />
     <link rel="stylesheet" type="text/css" href="stylesheets/print.css" media="print" />
     <!--[if lt IE 9]>
-    <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
+      <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     <title>ndjson</title>
   </head>
@@ -21,44 +21,53 @@
           <h1><span class="prefix">nd</span>json <span class="subtitle">Newline Delimited JSON</span></h1>
         </header>
 
-<nav><ul>
-<li><a href="/">Home</a></li>
-<li><a href="http://dataprotocols.org/ndjson/">Spec</a></li>
-<li>Libraries</li>
-</ul></nav>
+        <nav><ul>
+            <li><a href="/">Home</a></li>
+            <li><a href="http://dataprotocols.org/ndjson/">Spec</a></li>
+            <li>Libraries</li>
+          </ul></nav>
 
-        <hr>
+          <hr>
 
-        <p>
-        These libraries can be used to generate or parse NDJSON in different languages. Not
-        all of them follow the exact specification. If you want to add your own library, just
-        open a <a href="https://github.com/ndjson/ndjson.github.io/issues">pull request</a> on
-        this page.
-        </p>
+          <p>
+          These libraries can be used to generate or parse NDJSON in different languages. Not
+          all of them follow the exact specification. If you want to add your own library, just
+          open a <a href="https://github.com/ndjson/ndjson.github.io/issues">pull request</a> on
+          this page.
+          </p>
 
 
-        <section id="main_content">
-          <h4>JavaScript</h4>
-          - <a href="https://www.npmjs.com/package/ndjson">ndjson</a>
-          
-          <h4>Ruby</h4>
-          - <a href="https://github.com/ndjson/ndjson.rb">ndjson.rb</a>
+          <section id="main_content">
+            <h4>JavaScript</h4>
+            <ul>
+              <li><a href="https://www.npmjs.com/package/ndjson">ndjson</a></li>
+              <li><a href="https://github.com/mawni/nldj">nldj</a></li>
+            </ul>
 
-          <h4>R</h4>
-          - <a href="http://www.rdocumentation.org/packages/jsonlite/functions/stream_in">jsonlite</a>
-          
-          <h4>Haskell</h4>
-          - <a href="https://hackage.haskell.org/package/ndjson-conduit">ndjson-conduit</a>
+            <h4>Ruby</h4>
+            <ul>
+              <li><a href="https://github.com/ndjson/ndjson.rb">ndjson.rb</a></li>
+            </ul>
 
-        </section>
-        <footer>
+            <h4>R</h4>
+            <ul>
+              <li><a href="http://www.rdocumentation.org/packages/jsonlite/functions/stream_in">jsonlite</a></li>
+            </ul>
 
-          <a href="https://github.com/ndjson">NDJSON on GitHub</a> &bull;
-          Based on a theme by <a href="https://twitter.com/jasonlong">Jason Long</a> &bull;
-          Site forked from <a href="http://jsonlines.org">jsonlines.org</a>
-        </footer>
+            <h4>Haskell</h4>
+            <ul>
+              <li><a href="https://hackage.haskell.org/package/ndjson-conduit">ndjson-conduit</a></li>
+            </ul>
 
-        
+          </section>
+          <footer>
+
+            <a href="https://github.com/ndjson">NDJSON on GitHub</a> &bull;
+            Based on a theme by <a href="https://twitter.com/jasonlong">Jason Long</a> &bull;
+            Site forked from <a href="http://jsonlines.org">jsonlines.org</a>
+          </footer>
+
+
       </div>
     </div>
   </body>


### PR DESCRIPTION
Hi,

I've written a node.js module, [nldj](https://github.com/mawni/nldj) for parsing/serializing `ndjson` which is in compliance with the [NDJSON specification](https://github.com/ndjson/ndjson-spec). So, I added the `nldj` link to `libraries`. I also put library links of all languages in a `<ul></ul>`. I am sorry that I did it without discussing with you. I simply thought it gives it a better appearance and organization as well as makes it easier for people add libraries in the future.

**_A little note:_**
I personally like the [https://github.com/maxogden/ndjson](https://github.com/maxogden/ndjson) module. It is pretty solid and I like the simplicity of the implementation. However, it doesn't follow the exact specification. So, I tried to extend the idea a bit and make `nldj` somehow compliant with the specification.

I'd like to know what you think. Thanks.

