### PR TITLE
Add a link to an RxJS-based parser

### DIFF
--- a/libraries.html
+++ b/libraries.html
@@ -41,6 +41,7 @@
           <h4>JavaScript</h4>
           - <a href="https://www.npmjs.com/package/ndjson">ndjson</a>
           - <a href="https://www.npmjs.com/package/ld-jsonstream">ld-jsonstream</a>
+          - <a href="https://www.npmjs.com/package/ndjson-rxjs">ndjson-rxjs</a>
 
           <h4>Python</h4>
           - <a href="https://jsonlines.readthedocs.io/">jsonlines</a> (handles ndjson as well)


### PR DESCRIPTION
`ndjson-rxjs` is a Javascript parser for use on the client side (getting its data from an XMLHttpRequest) delivering results via an RxJS Observable.  It seems different enough from the existing implementations that it should probably be linked as well.