### PR TITLE
Add ArduinoJson to the list of libraries

### DIFF
--- a/libraries.html
+++ b/libraries.html
@@ -68,6 +68,9 @@
           
           <h4>C#</h4>
           - <a href="https://github.com/fredeil/dotnet-ndjson">dotnet-ndjson</a>
+          
+          <h4>C++</h4>
+          - <a href="https://arduinojson.org">ArduinoJson</a>
         </section>
         <footer>
 


### PR DESCRIPTION
When parsing a JSON document from an input stream, ArduinoJson stops reading as soon as the document ends.
This feature allows to read JSON documents one after the other; in particular, it allows to read line-delimited formats like NDJSON.